### PR TITLE
set specific version for eventlet(0.30.2)

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -1,7 +1,8 @@
 # NOTE: OpenStack avoids some versions of eventlet, because of the
 # following issue.
 # https://github.com/eventlet/eventlet/issues/401
-eventlet!=0.18.3,>=0.18.2,!=0.20.1,!=0.21.0,!=0.23.0
+# https://github.com/eventlet/eventlet/issues/702
+eventlet==0.30.2
 msgpack>=0.3.0,<1.0.0  # RPC library, BGP speaker(net_cntl)
 netaddr
 oslo.config>=2.5.0


### PR DESCRIPTION
workaround for 
```
File "/usr/lib/python3.9/site-packages/ryu/app/wsgi.py", line 109, in <module>
    class _AlreadyHandledResponse(Response):
  File "/usr/lib/python3.9/site-packages/ryu/app/wsgi.py", line 111, in _AlreadyHandledResponse
    from eventlet.wsgi import ALREADY_HANDLED
ImportError: cannot import name 'ALREADY_HANDLED' from 'eventlet.wsgi' (/usr/lib/python3.9/site-packages/eventlet/wsgi.py)
```